### PR TITLE
Fix #21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 
     // https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit
     compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '2.2.0.201212191850-r'
+
+    // https://mvnrepository.com/artifact/org.springframework/spring-test
+    testCompile group: 'org.springframework', name: 'spring-test', version: '4.0.5.RELEASE'
+
 }
 
 test {

--- a/src/main/java/ciserver/ContinuousIntegrationServer.java
+++ b/src/main/java/ciserver/ContinuousIntegrationServer.java
@@ -35,6 +35,32 @@ import org.eclipse.jgit.api.errors.JGitInternalException;
   */
 public class ContinuousIntegrationServer extends AbstractHandler
 {
+    public ContinuousIntegrationServer() {}
+
+    public String[] parseJSON(HttpServletRequest request) {
+        String[] parsedData = new String[2];
+        try {
+            JSONObject obj = new JSONObject(request.getReader().lines().collect(Collectors.joining(System.lineSeparator())));
+            try {
+                parsedData[0] = obj.getJSONObject("repository").getString("url");
+            } catch (JSONException e) {
+                throw new java.lang.Error("Error occured parsing the GitHub url");
+            }
+            try {
+                parsedData[1] = obj.getString("ref");
+            } catch (JSONException e) {
+                throw new java.lang.Error("Error occured parsing the branch name");
+            }
+        } catch (JSONException e) {
+            throw new java.lang.Error("Error occured parsing the request");
+        } catch (IOException e) {
+            throw new java.lang.Error("Error occured parsing the request");
+        } catch (NullPointerException e) {
+            throw new java.lang.Error("Request was empty");
+        }
+        return parsedData;
+    }
+
     public void handle(String target,
             Request baseRequest,
             HttpServletRequest request,
@@ -48,9 +74,11 @@ public class ContinuousIntegrationServer extends AbstractHandler
         System.out.println("Request method:");
         System.out.println(request.getMethod());
 
-        JSONObject obj = new JSONObject(request.getReader().lines().collect(Collectors.joining(System.lineSeparator())));
-        String url = obj.getJSONObject("repository").getString("url");
-        String branch = obj.getString("ref");
+        String[] parsedData = parseJSON(request);
+        if (parsedData == null)
+            return;
+        String url = parsedData[0];
+        String branch = parsedData[1];
 
         String cloneDir = "~/CI";
         try {

--- a/src/test/java/ciserver/ContinuousIntegrationServerTest.java
+++ b/src/test/java/ciserver/ContinuousIntegrationServerTest.java
@@ -4,9 +4,49 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import org.json.*;
+
 class ContinuousIntegrationServerTest {
     @Test
     public void testSample() {
         //fail();
+    }
+
+    /**
+     * Tests the functionality of the parseJSON function, both that
+     * the error handling works and that it returns the url and ref
+     * of requests on the correct format,
+     */
+    @Test
+    public void testJSONErrorHandling() {
+        ContinuousIntegrationServer ci = new ContinuousIntegrationServer();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        try { //An empty request
+            ci.parseJSON(request);
+            fail("An empty request should result in an error");
+        } catch (java.lang.Error e) {}
+
+        byte[] b = "dummy".getBytes();
+        request.setContent(b);
+        try { //A request with wrong content
+            ci.parseJSON(request);
+            fail("A request with wrong content should also result in an error");
+        } catch (java.lang.Error e) {}
+
+
+        MockHttpServletRequest request2 = new MockHttpServletRequest();
+        JSONObject obj = new JSONObject();
+        JSONObject repo = new JSONObject();
+        repo.put("url", "test_url");
+        obj.put("repository", repo);
+        obj.put("ref", "test_ref");
+        byte[] jsonBytes = obj.toString().getBytes();
+        request2.setContent(jsonBytes); //A request on the correct format
+        String[] result = ci.parseJSON(request2);
+
+        assertEquals(result[0], "test_url");
+        assertEquals(result[1], "test_ref");
     }
 }


### PR DESCRIPTION
Add function that parses requests and throws error if the github repo url or github branch couldn't be fetched. A test for the function is also included. 